### PR TITLE
Update sample models to 2.0, add validator script

### DIFF
--- a/2.0/AnimatedTriangle/glTF/AnimatedTriangle.gltf
+++ b/2.0/AnimatedTriangle/glTF/AnimatedTriangle.gltf
@@ -1,77 +1,77 @@
 {
-  "scenes" : {
-    "scene0" : {
-      "nodes" : [ "node0" ]
+  "scenes" : [
+    {
+      "nodes" : [ 0 ]
     }
-  },
-  "nodes" : {
-    "node0" : {
-      "meshes" : [ "mesh0" ],
+  ],
+  "nodes" : [
+    {
+      "mesh" : 0,
       "rotation" : [ 0.0, 0.0, 0.0, 1.0 ]
     }
-  },
-  "meshes" : {
-    "mesh0" : {
+  ],
+  "meshes" : [
+    {
       "primitives" : [ {
         "attributes" : {
-          "POSITION" : "positionsAccessor"
+          "POSITION" : 1
         },
-        "indices" : "indicesAccessor"
+        "indices" : 0
       } ]
     }
-  },
-  
-  "animations": {
-    "animation0": {
-      "samplers" : {
-        "rotationSampler" : {
-          "input" : "TIMEAccessor",
+  ],
+
+  "animations": [
+    {
+      "samplers" : [
+        {
+          "input" : 2,
           "interpolation" : "LINEAR",
-          "output" : "rotationAccessor"
+          "output" : 3
         }
-      },
+      ],
       "channels" : [ {
-        "sampler" : "rotationSampler",
+        "sampler" : 0,
         "target" : {
-          "id" : "node0",
+          "node" : 0,
           "path" : "rotation"
         }
       } ]
     }
-  },
+  ],
 
-  "buffers" : {
-    "geometryBuffer" : {
+  "buffers" : [
+    {
       "uri" : "simpleTriangle.bin",
       "byteLength" : 44
     },
-    "animationBuffer" : {
+    {
       "uri" : "animation.bin",
       "byteLength" : 100
     }
-  },
-  "bufferViews" : {
-    "indicesBufferView" : {
-      "buffer" : "geometryBuffer",
+  ],
+  "bufferViews" : [
+    {
+      "buffer" : 0,
       "byteOffset" : 0,
       "byteLength" : 6,
       "target" : 34963
     },
-    "attributesBufferView" : {
-      "buffer" : "geometryBuffer",
+    {
+      "buffer" : 0,
       "byteOffset" : 8,
       "byteLength" : 36,
       "target" : 34962
     },
-    "animationBufferView" : {
-      "buffer" : "animationBuffer",
+    {
+      "buffer" : 1,
       "byteOffset" : 0,
       "byteLength" : 100
     }
-  },
-  "accessors" : {
-    "indicesAccessor" : {
-      "bufferView" : "indicesBufferView",
+  ],
+  "accessors" : [
+    {
+      "bufferView" : 0,
       "byteOffset" : 0,
       "componentType" : 5123,
       "count" : 3,
@@ -79,8 +79,8 @@
       "max" : [ 2 ],
       "min" : [ 0 ]
     },
-    "positionsAccessor" : {
-      "bufferView" : "attributesBufferView",
+    {
+      "bufferView" : 1,
       "byteOffset" : 0,
       "componentType" : 5126,
       "count" : 3,
@@ -88,8 +88,8 @@
       "max" : [ 1.0, 1.0, 0.0 ],
       "min" : [ 0.0, 0.0, 0.0 ]
     },
-    "TIMEAccessor" : {
-      "bufferView" : "animationBufferView",
+    {
+      "bufferView" : 2,
       "byteOffset" : 0,
       "componentType" : 5126,
       "count" : 5,
@@ -97,8 +97,8 @@
       "max" : [ 1.0 ],
       "min" : [ 0.0 ]
     },
-    "rotationAccessor" : {
-      "bufferView" : "animationBufferView",
+    {
+      "bufferView" : 2,
       "byteOffset" : 20,
       "componentType" : 5126,
       "count" : 5,
@@ -106,10 +106,10 @@
       "max" : [ 0.0, 0.0, 1.0, 1.0 ],
       "min" : [ 0.0, 0.0, 0.0, -0.707 ]
     }
-  },
-  
+  ],
+
   "asset" : {
-    "version" : "1.1"
+    "version" : "2.0"
   }
-  
+
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gltf-sample-models",
+  "version": "1.0.0",
+  "description": "<p align=\"center\">\r <img src=\"https://raw.githubusercontent.com/KhronosGroup/glTF/master/specification/figures/gltf.png\">\r </p>",
+  "main": "validate.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KhronosGroup/glTF-Sample-Models.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/KhronosGroup/glTF-Sample-Models/issues"
+  },
+  "homepage": "https://github.com/KhronosGroup/glTF-Sample-Models#readme",
+  "dependencies": {
+    "jsonschema": "^1.1.1",
+    "mz": "^2.6.0"
+  }
+}

--- a/validate.js
+++ b/validate.js
@@ -45,9 +45,7 @@ fs.readdir(schemaPath)
     v.addSchema(mapping['/glTF.schema.json'], '/glTF.schema.json');
     while(v.unresolvedRefs.length > 0){
         let ref = v.unresolvedRefs.shift();
-        console.log('adding', ref);
         v.addSchema(mapping[ref], ref);
-        //console.log('remaining', v.unresolvedRefs);
     }
 
     // load the file to test
@@ -59,7 +57,10 @@ fs.readdir(schemaPath)
 .catch(err)
 // validate it
 .then(json => {
-    let result = v.validate(json, v.schemas['/glTF.schema.json'], {nestedErrors: true});
-    console.log('Validation passed');
+    let result = v.validate(json, v.schemas['/glTF.schema.json'], {nestedErrors: true, throwErrors: false});
+    if(result.errors.length === 0)
+        console.log('Validation passed');
+    else
+        console.log(result.errors);
 })
 .catch(err);

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const fs = require('mz/fs'),
+    libpath = require('path'),
+    Validator = require('jsonschema').Validator;
+
+var schemaPath = libpath.resolve(__dirname, '../glTF/specification/2.0/schema');
+
+var v = new Validator();
+
+function err(e){
+    console.error('Error:', e);
+}
+
+// read the schema directory
+fs.readdir(schemaPath)
+.catch(err)
+.then(files => {
+    // take only the json files from that directory
+    files = files.filter(f => /\.json$/.test(f));
+    return Promise.all(
+        // and read them
+        files.map(f => fs.readFile( libpath.join(schemaPath, f) ) )
+    )
+    .catch(err)
+    .then(filesContents => {
+        // pair file names with file contents
+        let mapping = {};
+        files.forEach((file, i) => {
+            try {
+                file = '/'+file;
+                mapping[file] = JSON.parse(filesContents[i]);
+                mapping[file].id = file;
+            }
+            catch(e){
+                console.error('Error parsing', file, filesContents[i]);
+            }
+        });
+        return Promise.resolve(mapping);
+    });
+})
+.catch(err)
+.then(mapping => {
+    // then apply those name/schema pairs to the validator
+    v.addSchema(mapping['/glTF.schema.json'], '/glTF.schema.json');
+    while(v.unresolvedRefs.length > 0){
+        let ref = v.unresolvedRefs.shift();
+        console.log('adding', ref);
+        v.addSchema(mapping[ref], ref);
+        //console.log('remaining', v.unresolvedRefs);
+    }
+
+    // load the file to test
+    return fs.readFile( libpath.resolve(__dirname, process.argv[process.argv.length-1]) );
+})
+.catch(err)
+// parse the given file
+.then(file => Promise.resolve(JSON.parse(file)))
+.catch(err)
+// validate it
+.then(json => {
+    let result = v.validate(json, v.schemas['/glTF.schema.json'], {nestedErrors: true});
+    console.log('Validation passed');
+})
+.catch(err);


### PR DESCRIPTION
I'm working on updating the 2.0 model samples to the latest spec revision. To aid in this effort, I've written a little JSON schema validator script, thought I may as well check it in.

Models to go:

* [ ] AdvancedMaterial (plain)
* [ ] AdvancedMaterial (binary)
* [x] AnimatedTriangle (plain)
* [ ] AnimatedTriangle (binary)
* [x] BoomBox (plain)
* [x] BoomBox (binary)
* [x] BoomBox (spec-glossy)
* [x] Cameras (plain)
* [ ] Cameras (binary)
* [x] Corset (plain)
* [x] Corset (binary)
* [x] Corset (spec-glossy)
* [x] Lantern (plain)
* [x] Lantern (binary)
* [x] Lantern (spec-glossy)
* [ ] SimpleMaterial (plain)
* [ ] SimpleMaterial (binary)
* [x] SimpleMeshes (plain)
* [ ] SimpleMeshes (binary)
* [ ] SimpleOpacity (plain)
* [ ] SimpleOpacity (binary)
* [ ] SimpleSkin (plain)
* [ ] SimpleSkin (binary)
* [ ] SimpleTexture (plain)
* [ ] SimpleTexture (binary)
* [x] Triangle (plain)
* [ ] Triangle (binary)
* [x] TriangleWithoutIndices (plain)
* [ ] TriangleWithoutIndices (binary)