### PR TITLE
Update all Cesium-supplied 2.0 models to use the CC 4.0 license.

### DIFF
--- a/2.0/Box/README.md
+++ b/2.0/Box/README.md
@@ -6,3 +6,5 @@
 ## License Information
 
 Donated by [Cesium](http://cesiumjs.org/) for glTF testing.
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/2.0/BoxAnimated/README.md
+++ b/2.0/BoxAnimated/README.md
@@ -6,3 +6,5 @@
 ## License Information
 
 Donated by [Cesium](http://cesiumjs.org/) for glTF testing.
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/2.0/BoxInterleaved/README.md
+++ b/2.0/BoxInterleaved/README.md
@@ -6,3 +6,5 @@
 ## License Information
 
 Donated by [Cesium](http://cesiumjs.org/) and interleaved by [AngeloReppucci](https://github.com/AngeloReppucci) for glTF testing.
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/2.0/BoxTextured/README.md
+++ b/2.0/BoxTextured/README.md
@@ -6,3 +6,5 @@
 ## License Information
 
 Donated by Cesium for glTF testing.  Please follow the [Cesium Trademark Terms and Conditions](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CesiumTrademark.pdf).
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/2.0/BoxTexturedNonPowerOfTwo/README.md
+++ b/2.0/BoxTexturedNonPowerOfTwo/README.md
@@ -13,3 +13,5 @@ See the Non-Power-Of-Two note at the bottom of the [Samplers section](https://gi
 ## License Information
 
 Donated by Cesium for glTF testing.  Please follow the [Cesium Trademark Terms and Conditions](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CesiumTrademark.pdf).
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/2.0/CesiumMan/README.md
+++ b/2.0/CesiumMan/README.md
@@ -6,3 +6,5 @@
 ## License Information
 
 Donated by Cesium for glTF testing.  Please follow the [Cesium Trademark Terms and Conditions](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CesiumTrademark.pdf).
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/2.0/CesiumMilkTruck/README.md
+++ b/2.0/CesiumMilkTruck/README.md
@@ -6,3 +6,5 @@
 ## License Information
 
 Donated by Cesium for glTF testing.  Please follow the [Cesium Trademark Terms and Conditions](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CesiumTrademark.pdf).
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/2.0/RiggedFigure/README.md
+++ b/2.0/RiggedFigure/README.md
@@ -6,3 +6,5 @@
 ## License Information
 
 Donated by [Cesium](http://cesiumjs.org/) for glTF testing.
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/2.0/RiggedSimple/README.md
+++ b/2.0/RiggedSimple/README.md
@@ -6,3 +6,5 @@
 ## License Information
 
 Donated by [Cesium](http://cesiumjs.org/) for glTF testing.
+
+This model is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Fixes #188.

Not trying to add any new legal requirements here, just trying to clarify that these sample models are being shared intentionally with everyone.