### PR TITLE
Tweak pirate model link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Sample models help the glTF ecosystem, if you are able to contribute a model, se
 
 * [Sketchfab](https://sketchfab.com/features/gltf) offers auto-conversion of all of its downloadable models, including PBR models, to glTF format.
 * Microsoft's [Remix3D](https://www.remix3d.com/) can download 3D models into Paint3D, which offers a "Save As GLB" export (GLB is the binary form of glTF).
+* Google's [Poly](https://poly.google.com/) offers certain 3D assets for download in glTF format.
 
 ## Other glTF Models
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For addition glTF models, see:
 * Flightradar24's [GitHub repo](https://github.com/kalmykov/fr24-3d-models) of aircrafts.
 * Sketchfab's [glTF samples](https://sketchfab.com/features/gltf).
 * [Kenney • Assets](https://kenney.nl/assets?q=3d) hundreds of themed low-poly assets (nature, space, castle, furniture, etc.) provided by Kenney under CC0 licenses.
-* [30+ pirate themed (public domain) models](https://www.reddit.com/r/gamedev/comments/9i88rb/over_30_pirate_themed_public_domain_models/)
+   * [30+ pirate themed models](https://kenney.nl/assets/pirate-kit) by Kenney under CC0 license.
 
 ## Contributing Sample Models
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Sample models help the glTF ecosystem, if you are able to contribute a model, se
 ## Model Publishing Services with glTF Download Capability
 
 * [Sketchfab](https://sketchfab.com/features/gltf) offers auto-conversion of all of its downloadable models, including PBR models, to glTF format.
-* Microsoft's [Remix3D](https://www.remix3d.com/) can download 3D models into Paint3D, which offers a "Save As GLB" export (GLB is the binary form of glTF).
-* Google's [Poly](https://poly.google.com/) offers certain 3D assets for download in glTF format.
+* [Microsoft's Remix3D](https://www.remix3d.com/) can download 3D models into Paint3D, which offers a "Save As GLB" export (GLB is the binary form of glTF).
+* [Google's Poly](https://poly.google.com/) offers certain 3D assets for download in glTF format.
 
 ## Other glTF Models
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,17 @@ See the `README.md` in each model's directory for usage restrictions.
 
 Sample models help the glTF ecosystem, if you are able to contribute a model, see the [contributing section](#contributing-sample-models) below.
 
-## Other glTF Sample Models
+## Model Publishing Services with glTF Download Capability
+
+* [Sketchfab](https://sketchfab.com/features/gltf) offers auto-conversion of all of its downloadable models, including PBR models, to glTF format.
+* Microsoft's [Remix3D](https://www.remix3d.com/) can download 3D models into Paint3D, which offers a "Save As GLB" export (GLB is the binary form of glTF).
+
+## Other glTF Models
 
 For addition glTF models, see:
 
 * Cesium's [demo models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Apps/SampleData/models) and [unit test models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Specs/Data/Models).
 * Flightradar24's [GitHub repo](https://github.com/kalmykov/fr24-3d-models) of aircrafts.
-* Sketchfab's [glTF samples](https://sketchfab.com/features/gltf).
 * [Kenney • Assets](https://kenney.nl/assets?q=3d) hundreds of themed low-poly assets (nature, space, castle, furniture, etc.) provided by Kenney under CC0 licenses.
    * [30+ pirate themed models](https://kenney.nl/assets/pirate-kit) by Kenney under CC0 license.
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 [![Build Status](https://travis-ci.org/KhronosGroup/glTF-Sample-Models.svg?branch=master)](https://travis-ci.org/KhronosGroup/glTF-Sample-Models)
 
 - [glTF 1.0](1.0)
-- [glTF 2.0](2.0)
+- [glTF 2.0](2.0) - Click for full list.
 
-Sample glTF 2.0 models are provided in as many of the following formats as possible:
-* glTF (.gltf) with separate resources: .bin (geometry, animation, skins), .glsl (shaders), and image files
-* glTF (.gltf) with embedded resources
-* Binary glTF (.glb) using the [binary container format](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification)
-* glTF (.gltf) using the [KHR_materials_pbrSpecularGlossiness](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness) extension
-* Original COLLADA (.dae) or other source format
+Sample glTF 2.0 models are provided in one or more of the following forms of glTF:
 
-See the `README.md` in each model's directory for usage restrictions.
+* glTF (`.gltf`) with separate resources: `.bin` (geometry, animation, skins) and `.jpg` or `.png` image files.  The supporting files are easily examined when separated like this, but must be kept together with the parent glTF file for the model to work.
+* glTF (`.gltf`) with embedded resources (as Data URIs).  This form tends to be larger than the others, but Data URIs do have their uses.
+* Binary glTF (`.glb`) using the [binary container format](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification).  These are easily shared due to the bundling of all the textures and mesh data into a single file.
+* glTF (`.gltf`) using the [KHR_materials_pbrSpecularGlossiness](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness) extension.  This is an alternate PBR (Physically Based Rendering) workflow that gives model artists an extra degree of freedom over glTF's core metallic/roughness PBR workflow.
+
+See the `README.md` in each model's directory for license information.
 
 Sample models help the glTF ecosystem, if you are able to contribute a model, see the [contributing section](#contributing-sample-models) below.
 
@@ -32,8 +32,7 @@ For addition glTF models, see:
 
 * Cesium's [demo models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Apps/SampleData/models) and [unit test models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Specs/Data/Models).
 * Flightradar24's [GitHub repo](https://github.com/kalmykov/fr24-3d-models) of aircrafts.
-* [Kenney • Assets](https://kenney.nl/assets?q=3d) hundreds of themed low-poly assets (nature, space, castle, furniture, etc.) provided by Kenney under CC0 licenses.
-   * [30+ pirate themed models](https://kenney.nl/assets/pirate-kit) by Kenney under CC0 license.
+* [Kenney • Assets](https://kenney.nl/assets?q=3d) hundreds of themed low-poly assets (nature, space, castle, furniture, etc.) provided by Kenney under CC0 licenses, including [30+ pirate themed models](https://kenney.nl/assets/pirate-kit).
 
 ## Contributing Sample Models
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Sample models help the glTF ecosystem, if you are able to contribute a model, se
 
 For addition glTF models, see:
 
+* [Khronos glTF Asset Generator](https://github.com/KhronosGroup/glTF-Asset-Generator) offers an extensive suite of test models to excersise each part of the glTF specification.
 * Cesium's [demo models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Apps/SampleData/models) and [unit test models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Specs/Data/Models).
 * Flightradar24's [GitHub repo](https://github.com/kalmykov/fr24-3d-models) of aircrafts.
 * [Kenney • Assets](https://kenney.nl/assets?q=3d) hundreds of themed low-poly assets (nature, space, castle, furniture, etc.) provided by Kenney under CC0 licenses, including [30+ pirate themed models](https://kenney.nl/assets/pirate-kit).


### PR DESCRIPTION
Replace the reddit link with the asset download link, and make it a sub-bullet under "Kenney Assets" which was already in place above.