### PR TITLE
Fix Linear Scale test in InterpolationTest.

### DIFF
--- a/2.0/InterpolationTest/glTF/InterpolationTest.gltf
+++ b/2.0/InterpolationTest/glTF/InterpolationTest.gltf
@@ -537,7 +537,7 @@
             "samplers" : [
                 {
                     "input" : 42,
-                    "interpolation" : "CUBICSPLINE",
+                    "interpolation" : "LINEAR",
                     "output" : 43
                 }
             ]


### PR DESCRIPTION
The animation whose name is `Linear Scale` is mistakenly using `CUBICSPLINE`.