### PR TITLE
Fix LinearScale input accessor count.

### DIFF
--- a/2.0/InterpolationTest/glTF/InterpolationTest.gltf
+++ b/2.0/InterpolationTest/glTF/InterpolationTest.gltf
@@ -373,7 +373,7 @@
         {
             "bufferView" : 43,
             "componentType" : 5126,
-            "count" : 15,
+            "count" : 5,
             "type" : "VEC3"
         },
         {


### PR DESCRIPTION
Validation and visual testing reveals that this animation expects 5 elements but the accessor contains 15 elements.