### PR TITLE
FlightHelmet: Removed unneeded doubleSided.

### DIFF
--- a/2.0/FlightHelmet/glTF/FlightHelmet.gltf
+++ b/2.0/FlightHelmet/glTF/FlightHelmet.gltf
@@ -532,7 +532,6 @@
       "name": "MetalPartsMat"
     },
     {
-      "doubleSided": true,
       "pbrMetallicRoughness": {
         "baseColorTexture": {
           "index": 12


### PR DESCRIPTION
I think the doubleSided is not necessary in this material.

This was indirectly discovered due to gpus with double-sided related driver bugs.

Related:
https://github.com/GoogleWebComponents/model-viewer/issues/740
https://github.com/mrdoob/three.js/issues/15850
https://github.com/mrdoob/three.js/pull/17158