### PR TITLE
Added "scene" property to simple test models

### DIFF
--- a/2.0/AnimatedTriangle/glTF-Embedded/AnimatedTriangle.gltf
+++ b/2.0/AnimatedTriangle/glTF-Embedded/AnimatedTriangle.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0 ]

--- a/2.0/AnimatedTriangle/glTF/AnimatedTriangle.gltf
+++ b/2.0/AnimatedTriangle/glTF/AnimatedTriangle.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0 ]

--- a/2.0/Cameras/glTF-Embedded/Cameras.gltf
+++ b/2.0/Cameras/glTF-Embedded/Cameras.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0, 1, 2 ]

--- a/2.0/Cameras/glTF/Cameras.gltf
+++ b/2.0/Cameras/glTF/Cameras.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0, 1, 2 ]

--- a/2.0/SimpleMeshes/glTF-Embedded/SimpleMeshes.gltf
+++ b/2.0/SimpleMeshes/glTF-Embedded/SimpleMeshes.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0, 1]

--- a/2.0/SimpleMeshes/glTF/SimpleMeshes.gltf
+++ b/2.0/SimpleMeshes/glTF/SimpleMeshes.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0, 1]

--- a/2.0/SimpleMorph/glTF-Embedded/SimpleMorph.gltf
+++ b/2.0/SimpleMorph/glTF-Embedded/SimpleMorph.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes":[
     {
       "nodes":[

--- a/2.0/SimpleMorph/glTF/SimpleMorph.gltf
+++ b/2.0/SimpleMorph/glTF/SimpleMorph.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes":[
     {
       "nodes":[

--- a/2.0/SimpleSparseAccessor/glTF-Embedded/SimpleSparseAccessor.gltf
+++ b/2.0/SimpleSparseAccessor/glTF-Embedded/SimpleSparseAccessor.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [ {
     "nodes" : [ 0 ]
   } ],

--- a/2.0/SimpleSparseAccessor/glTF/SimpleSparseAccessor.gltf
+++ b/2.0/SimpleSparseAccessor/glTF/SimpleSparseAccessor.gltf
@@ -1,4 +1,5 @@
 {
+   "scene" : 0,
    "scenes":[
       {
          "nodes":[

--- a/2.0/Triangle/glTF-Embedded/Triangle.gltf
+++ b/2.0/Triangle/glTF-Embedded/Triangle.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0 ]

--- a/2.0/Triangle/glTF/Triangle.gltf
+++ b/2.0/Triangle/glTF/Triangle.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0 ]

--- a/2.0/TriangleWithoutIndices/glTF-Embedded/TriangleWithoutIndices.gltf
+++ b/2.0/TriangleWithoutIndices/glTF-Embedded/TriangleWithoutIndices.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0 ]

--- a/2.0/TriangleWithoutIndices/glTF/TriangleWithoutIndices.gltf
+++ b/2.0/TriangleWithoutIndices/glTF/TriangleWithoutIndices.gltf
@@ -1,4 +1,5 @@
 {
+  "scene" : 0,
   "scenes" : [
     {
       "nodes" : [ 0 ]


### PR DESCRIPTION
According to the specification, the runtime is not required
to render anything when the scene property is undefined.

Fixes https://github.com/KhronosGroup/glTF-Sample-Models/issues/240 

