### PR TITLE
Fixes SpecularSpheres test model to assign correct materials to meshes.

### DIFF
--- a/2.0/SpecularSpheres/glTF/SpecularSpheres.gltf
+++ b/2.0/SpecularSpheres/glTF/SpecularSpheres.gltf
@@ -31,7 +31,7 @@
             ]
         },
         {
-            "mesh" : 0,
+            "mesh" : 1,
             "name" : "Sphere 0.5",
 			"translation": [
                 0.0,
@@ -40,7 +40,7 @@
             ]
         },
         {
-            "mesh" : 0,
+            "mesh" : 2,
             "name" : "Sphere 1.0",
 			"translation": [
                 2.5,


### PR DESCRIPTION
All 3 nodes in this test model referred to mesh 0 (specularFactor set to 0).  This PR updates nodes 1 and 2 to use their intended meshes (for specular Factor 0.5 and 1.0).