### PR TITLE
Fix link for license

### DIFF
--- a/2.0/Duck/README.md
+++ b/2.0/Duck/README.md
@@ -9,6 +9,6 @@ Copyright 2006 Sony Computer Entertainment Inc.
 
 Licensed under the SCEA Shared Source License, Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:
 
-http://research.scea.com/scea_shared_source_license.html
+https://web.archive.org/web/20160320123355/http://research.scea.com/scea_shared_source_license.html
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
The original link (http://research.scea.com/scea_shared_source_license.html) points to an inactive website. The last time it was active according to the Wayback Machine was March 2016 (https://web.archive.org/web/20160320123355/http://research.scea.com/scea_shared_source_license.html).