### PR TITLE
Fix link to Smithonian 3D models

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For addition glTF models, see:
 * Cesium's [demo models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Apps/SampleData/models) and [unit test models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Specs/Data/Models).
 * Flightradar24's [GitHub repo](https://github.com/kalmykov/fr24-3d-models) of aircrafts.
 * [Kenney • Assets](https://kenney.nl/assets?q=3d) hundreds of themed low-poly assets (nature, space, castle, furniture, etc.) provided by Kenney under CC0 licenses, including [30+ pirate themed models](https://kenney.nl/assets/pirate-kit).
-* [Smithsonian open access 3D models](https://3d.si.edu/cc0?edan_q=*:*&edan_fq[]=online_media_type:%223D+Images%22)
+* [Smithsonian open access 3D models](https://3d.si.edu/explore)
 
 ## Contributing Sample Models
 


### PR DESCRIPTION
The old link showed an empty list of search results...
